### PR TITLE
standardize install scripts as much as possible

### DIFF
--- a/spells/system/install/bat.sh
+++ b/spells/system/install/bat.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
+# Install bat
 if command -v bat &>/dev/null || command -v batcat &>/dev/null; then
     log_debug "bat or batcat is already installed."
 else
     log_info "🔧 Installing bat..."
-    sudo apt-get update && sudo apt-get install -y bat
-    log_success "bat Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update && sudo apt-get install -y bat
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install bat
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+        log_success "🔧 bat Installed Successfully"
 fi
 
 # Add alias if not already present

--- a/spells/system/install/btop.sh
+++ b/spells/system/install/btop.sh
@@ -1,11 +1,19 @@
 #!/usr/bin/env bash
 
-if command -v btop &>/dev/null; then
-    log_debug "btop is already installed."
+# Install btop
+if ! command -v btop &> /dev/null; then
+    log_info "Installing btop..."
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update && sudo apt-get install -y btop
+        log_success "btop Installed Successfully"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install btop
+        log_success "btop Installed Successfully"
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
 else
-    log_info "🔧 Installing btop..."
-    sudo apt-get update && sudo apt-get install -y btop
-    log_success "btop Installed Successfully"
+    log_info "btop is already installed."
 fi
-
 log_info_box "To uninstall btop, run 'st system uninstall btop'."

--- a/spells/system/install/docker.sh
+++ b/spells/system/install/docker.sh
@@ -1,15 +1,22 @@
 #!/usr/bin/env bash
 
+#Install Docker
 if ! command -v docker &>/dev/null; then
     log_info "🔧 Installing Docker..."
-    sudo apt-get update -qq
-    curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq
+        curl -fsSL test.docker.com -o get-docker.sh && sh get-docker.sh
 
-    log_info_box "Please run the following commands to set up Docker permissions:"
-    log_warn "sudo groupadd docker"
-    log_warn "sudo usermod -aG docker $USER"
-    log_warn "newgrp docker"
-
+        log_info_box "Please run the following commands to set up Docker permissions:"
+        log_warn "sudo groupadd docker"
+        log_warn "sudo usermod -aG docker $USER"
+        log_warn "newgrp docker"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install docker
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
     log_success "🔧 Docker installation complete."
 else
     log_info "Docker is already installed."

--- a/spells/system/install/duf.sh
+++ b/spells/system/install/duf.sh
@@ -2,9 +2,15 @@
 
 if ! command -v duf &>/dev/null; then
     log_info "🔧 Installing duf..."
-    sudo apt-get update -qq
-    sudo apt-get install -y duf
-    log_success "duf Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq && sudo apt-get install -y duf
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install duf
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 duf Installed Successfully"
 else
     log_info "✅ duf is already installed."
 fi

--- a/spells/system/install/eza.sh
+++ b/spells/system/install/eza.sh
@@ -2,11 +2,17 @@
 
 if ! command -v eza &>/dev/null; then
     log_info "🔧 Installing eza..."
-    sudo apt-get update -qq
-    sudo apt-get install -y eza
-    log_success "eza Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq && sudo apt-get install -y eza
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install eza
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 eza Installed Successfully"
 else
-    log_info "eza is already installed."
+    log_info "✅ eza is already installed."
 fi
 
 log_info_box "To uninstall eza, run 'st system uninstall eza'."

--- a/spells/system/install/ncdu.sh
+++ b/spells/system/install/ncdu.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
+#Install ncdu
 if ! command -v ncdu &>/dev/null; then
     log_info "🔧 Installing ncdu..."
-    sudo apt-get update -qq
-    sudo apt-get install -y ncdu
-    log_success "ncdu Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq && sudo apt-get install -y ncdu
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install ncdu
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 ncdu Installed Successfully"
 else
-    log_info "ncdu is already installed."
+    log_info "✅ ncdu is already installed."
 fi
 
 log_info_box "To uninstall ncdu, run 'st system uninstall ncdu'."

--- a/spells/system/install/neofetch.sh
+++ b/spells/system/install/neofetch.sh
@@ -3,11 +3,17 @@
 # Install neofetch
 if ! command -v neofetch &>/dev/null; then
     log_info "🔧 Installing neofetch..."
-    sudo apt-get update -qq
-    sudo apt-get install -y neofetch
-    log_success "neofetch Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq && sudo apt-get install -y neofetch
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install neofetch
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 neofetch Installed Successfully"
 else
-    log_info "neofetch is already installed."
+    log_info "✅ neofetch is already installed."
 fi
 
 log_info_box "To uninstall neofetch, run 'st system uninstall neofetch'."

--- a/spells/system/install/rclone.sh
+++ b/spells/system/install/rclone.sh
@@ -2,16 +2,18 @@
 
 # Install rclone
 if ! command -v rclone &> /dev/null; then
-    log_info "Installing rclone..."
+    log_info "🔧 Installing rclone..."
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sudo apt install rclone -y
+        sudo apt-get update && sudo apt install rclone -y
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         brew install rclone
     else
         log_error "Unsupported OS: $OSTYPE"
         exit 1
     fi
+    log_success "🔧 rclone installation complete."
 else
-    log_info "rclone is already installed."
+    log_info "✅ rclone is already installed."
 fi
+
 log_info_box "To uninstall rclone, run 'st system uninstall rclone'."

--- a/spells/system/install/restic.sh
+++ b/spells/system/install/restic.sh
@@ -2,7 +2,7 @@
 
 # Install restic
 if ! command -v restic &> /dev/null; then
-    log_info "Installing restic..."
+    log_info "🔧 Installing restic..."
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
         sudo apt install restic -y
     elif [[ "$OSTYPE" == "darwin"* ]]; then
@@ -11,7 +11,9 @@ if ! command -v restic &> /dev/null; then
         log_error "Unsupported OS: $OSTYPE"
         exit 1
     fi
+    log_success "🔧 restic installation complete."
 else
-    log_info "restic is already installed."
+    log_info "✅ restic is already installed."
 fi
+
 log_info_box "To uninstall restic, run 'st system uninstall restic'."

--- a/spells/system/install/resticprofile.sh
+++ b/spells/system/install/resticprofile.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+#Install resticprofile
 if ! command -v resticprofile &>/dev/null; then
     log_info "Installing restic profile..."
 
@@ -7,6 +8,12 @@ if ! command -v resticprofile &>/dev/null; then
         curl -LO https://raw.githubusercontent.com/creativeprojects/resticprofile/master/install.sh
         chmod +x install.sh
         sudo ./install.sh -b /usr/local/bin
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        log_error "resticprofile is not supported on macOS. Please install it manually."
+        exit 1
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
     fi
 else
     log_info "resticprofile is already installed."

--- a/spells/system/install/ufw.sh
+++ b/spells/system/install/ufw.sh
@@ -1,14 +1,24 @@
 #!/usr/bin/env bash
 
+#Install ufw
 if ! command -v ufw &>/dev/null; then
     log_info "🔧 Installing ufw..."
-    sudo apt-get update -qq
-    sudo apt-get install -y ufw
-    log_info "🔧 Enabling ufw..."
-    sudo ufw allow 22
-    sudo ufw enable
-    log_success "ufw Installed Successfully"
-    log_info "🔧 Please run 'sudo ufw allow <port>' to allow other ports as needed. Then run 'sudo ufw enable' to enable the firewall"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq
+        sudo apt-get install -y ufw
+        log_info "🔧 Enabling ufw..."
+        sudo ufw allow 22
+        sudo ufw enable
+        log_success "ufw Installed Successfully"
+        log_info "🔧 Please run 'sudo ufw allow <port>' to allow other ports as needed. Then run 'sudo ufw enable' to enable the firewall"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        log_error "UFW is not supported on macOS. Please use the built-in firewall or another solution."
+        exit 1
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+
 else
     log_info "✅ ufw is already installed."
 fi

--- a/spells/system/install/vnstat.sh
+++ b/spells/system/install/vnstat.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 
+# Install vnstat
 if ! command -v vnstat &>/dev/null; then
     log_info "🔧 Installing vnstat..."
-    sudo apt-get update -qq
-    sudo apt-get install -y vnstat
-    log_success "vnstat Installed Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get update -qq && sudo apt-get install -y vnstat
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew install vnstat
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 vnstat Installed Successfully"
 else
-    log_info "vnstat is already installed."
+    log_info "✅ vnstat is already installed."
 fi
 
 log_info_box "To uninstall vnstat, run 'st system uninstall vnstat'."

--- a/spells/system/uninstall/bat.sh
+++ b/spells/system/uninstall/bat.sh
@@ -8,8 +8,16 @@ fi
 
 if command -v bat &>/dev/null || command -v batcat &>/dev/null; then
     log_info "🔧 Uninstalling bat..."
-    sudo apt-get remove -y bat
-    log_success "bat Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove -y bat
+        log_success "bat Uninstalled Successfully"
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall bat
+        log_success "bat Uninstalled Successfully"
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
 else
     log_debug "bat is already uninstalled."
 fi

--- a/spells/system/uninstall/btop.sh
+++ b/spells/system/uninstall/btop.sh
@@ -1,10 +1,17 @@
 #!/usr/bin/env bash
 
-if command -v btop &>/dev/null; then
-    sudo apt-get remove --purge -y btop
-    log_debug "btop Uninstalled Successfully"
+# Uninstall btop
+if command -v btop &> /dev/null; then
+    log_info "Uninstalling rclone..."
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y btop
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall btop
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
 else
     log_info "btop is not installed."
 fi
-
-log_info_box "To reinstall btop, run 'st system install btop'."
+log_info_box "To reinstall btop, run 'st system install rclone'."

--- a/spells/system/uninstall/duf.sh
+++ b/spells/system/uninstall/duf.sh
@@ -2,8 +2,15 @@
 
 if command -v duf &>/dev/null; then
     log_info "🔧 Uninstalling duf..."
-    sudo apt-get remove --purge -y duf
-    log_success "duf Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y duf
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall duf
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 duf Uninstalled Successfully"
 else
     log_info "duf is not installed."
 fi

--- a/spells/system/uninstall/eza.sh
+++ b/spells/system/uninstall/eza.sh
@@ -2,8 +2,15 @@
 
 if command -v eza &>/dev/null; then
     log_info "🔧 Uninstalling eza..."
-    sudo apt-get remove --purge -y eza
-    log_success "eza Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y eza
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall eza
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 eza Uninstalled Successfully"
 else
     log_info "eza is not installed."
 fi

--- a/spells/system/uninstall/ncdu.sh
+++ b/spells/system/uninstall/ncdu.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+#Uninstall ncdu
 if command -v ncdu &>/dev/null; then
     log_info "🔧 Uninstalling ncdu..."
-    sudo apt-get remove --purge -y ncdu
-    log_success "ncdu Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y ncdu
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall ncdu
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 ncdu Uninstalled Successfully"
 else
     log_info "ncdu is not installed."
 fi

--- a/spells/system/uninstall/neofetch.sh
+++ b/spells/system/uninstall/neofetch.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+# Uninstall neofetch
 if command -v neofetch &>/dev/null; then
     log_info "🔧 Uninstalling neofetch..."
-    sudo apt-get remove --purge -y neofetch
-    log_success "neofetch Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y neofetch
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall neofetch
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 neofetch Uninstalled Successfully"
 else
     log_info "neofetch is not installed."
 fi

--- a/spells/system/uninstall/rclone.sh
+++ b/spells/system/uninstall/rclone.sh
@@ -2,16 +2,18 @@
 
 # Uninstall rclone
 if command -v rclone &> /dev/null; then
-    log_info "Uninstalling rclone..."
+    log_info "🔧 Uninstalling rclone..."
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sudo apt remove rclone -y
+        sudo apt-get remove rclone -y
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         brew uninstall rclone
     else
         log_error "Unsupported OS: $OSTYPE"
         exit 1
     fi
+    log_success "🔧 rclone uninstallation complete."
 else
     log_info "rclone is not installed."
 fi
+
 log_info_box "To reinstall rclone, run 'st system install rclone'."

--- a/spells/system/uninstall/restic.sh
+++ b/spells/system/uninstall/restic.sh
@@ -4,14 +4,16 @@
 if command -v restic &> /dev/null; then
     log_info "Uninstalling restic..."
     if [[ "$OSTYPE" == "linux-gnu"* ]]; then
-        sudo apt remove restic -y
+        sudo apt-get remove restic -y
     elif [[ "$OSTYPE" == "darwin"* ]]; then
         brew uninstall restic
     else
         log_error "Unsupported OS: $OSTYPE"
         exit 1
     fi
+    log_success "🔧 restic uninstallation complete."
 else
     log_info "restic is not installed."
 fi
+
 log_info_box "To reinstall restic, run 'st system install restic'."

--- a/spells/system/uninstall/vnstat.sh
+++ b/spells/system/uninstall/vnstat.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 
+#Uninstall vnstat
 if command -v vnstat &>/dev/null; then
     log_info "🔧 Uninstalling vnstat..."
-    sudo apt-get remove --purge -y vnstat
-    log_success "vnstat Uninstalled Successfully"
+    if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+        sudo apt-get remove --purge -y vnstat
+    elif [[ "$OSTYPE" == "darwin"* ]]; then
+        brew uninstall vnstat
+    else
+        log_error "Unsupported OS: $OSTYPE"
+        exit 1
+    fi
+    log_success "🔧 vnstat Uninstalled Successfully"
 else
     log_info "vnstat is not installed."
 fi


### PR DESCRIPTION
Mainly just took your rclone script (which included logic for comparing between darwin + linux) and adapted it to the other install scripts which didn't include this logic. Checked the brew formulae on their website to double-check that the packages existed over there, added an "unsupported" error in places where it didn't (I think that was only UFW and resticprofile)

Happy to revise if you see issues.